### PR TITLE
Port hazelcast -> ignite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 target/
 .bloop
 .metals
+ignite/

--- a/README.md
+++ b/README.md
@@ -14,11 +14,11 @@ Form a local cluster by running 2-3 instances of the app. You can specify a port
 an argument to the project `Main` class.
 
 ```bash
-sbt run 9999
+sbt "run 9999"
 //...
-sbt run 10000
+sbt "run 10000"
 //...
-sbt run 10001
+sbt "run 10001"
 ```
 Once the nodes are up, one and only one of them will be holding a lock and populate a distributed
 map of current weather conditions (keyed by city). One can access to the current weather condition from any

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 lazy val akkaHttpVersion   = "10.1.11"
 lazy val akkaVersion       = "2.6.1"
-lazy val hazelcastVersion  = "4.0.2"
+lazy val igniteVersion     = "2.8.1"
 lazy val enumeratumVersion = "1.6.1"
 
 lazy val root = (project in file(".")).settings(
@@ -12,7 +12,7 @@ lazy val root = (project in file(".")).settings(
   libraryDependencies ++= Seq(
     "com.typesafe.akka" %% "akka-http"         % akkaHttpVersion,
     "com.typesafe.akka" %% "akka-stream"       % akkaVersion,
-    "com.hazelcast"      % "hazelcast"         % hazelcastVersion,
+    "org.apache.ignite"  % "ignite-core"       % igniteVersion,
     "ch.qos.logback"     % "logback-classic"   % "1.2.3",
     "org.typelevel"     %% "cats-effect"       % "2.1.3",
     "com.beachape"      %% "enumeratum"        % enumeratumVersion,
@@ -20,7 +20,7 @@ lazy val root = (project in file(".")).settings(
     "com.typesafe.akka" %% "akka-http-testkit" % akkaHttpVersion % Test,
     "org.scalatest"     %% "scalatest"         % "3.0.8"         % Test,
   ),
-  javaOptions ++= Seq("-Dhazelcast.shutdownhook.policy=GRACEFUL", "-Dhazelcast.graceful.shutdown.max.wait=600"),
+//  javaOptions ++= Seq("-Dhazelcast.shutdownhook.policy=GRACEFUL", "-Dhazelcast.graceful.shutdown.max.wait=600"),
   addCompilerPlugin("com.olegpy" %% "better-monadic-for" % "0.3.1"),
   mainClass in assembly := Some("com.example.imperative.Main"),
 )

--- a/src/main/scala/com/example/imperative/AdvertsFlow.scala
+++ b/src/main/scala/com/example/imperative/AdvertsFlow.scala
@@ -7,11 +7,11 @@ import akka.http.scaladsl.model.ws.TextMessage
 import akka.stream.scaladsl.Flow
 import akka.stream.scaladsl.Sink
 import akka.stream.scaladsl.Source
-import com.hazelcast.topic.ITopic
+import org.apache.ignite.IgniteMessaging
 
 object AdvertsFlow {
-  def apply(adsTopic: ITopic[Advert])(implicit as: ActorSystem): Flow[Message, Message, NotUsed] = {
-    val source = Source.fromGraph(new HZTopicSource(adsTopic)).map(ad => TextMessage(ad.toString): Message)
+  def apply(msg: IgniteMessaging)(implicit as: ActorSystem): Flow[Message, Message, NotUsed] = {
+    val source = Source.fromGraph(new IgniteTopicSource(msg, Topic.ads)).map(ad => TextMessage(ad.toString): Message)
     Flow.fromSinkAndSourceCoupled[Message, Message](Sink.foreach(println(">>> ", _)), source)
   }
 }


### PR DESCRIPTION
Have got the hatoy fully working with apache ignite.

The mechanism for running updates on a single node is by "deploying" a cluster singleton service - all seems a bit weird and there is probably a simpler way.

Listening for map changes is via a ContinuousQuery - but that will receive updates for all keys, which means there is duplicates when running this query on all nodes. I've added a "remote filter" so that it only fires updates where the query node == update node - but that is also a weird pattern and its probably better to make the query just run on one node instead.

General feelings is that it is more rough round the edges that hazelcast, with less tools in its toolbox - but all the fundamentals are there in one more or another.